### PR TITLE
Prevent forced first person when braking in vehicle on controller

### DIFF
--- a/client/cl_vehicles.lua
+++ b/client/cl_vehicles.lua
@@ -15,7 +15,7 @@ local function vehicleLoop(vehicle)
         if forceDriver or forcePassenger or isAiming and currentCam ~= 4 then
             setCamByVehicleType(4)
         else
-            if config.forceVehicleAimingFPP and IsControlJustReleased(0, 25) then
+            if config.forceVehicleAimingFPP and (IsControlJustReleased(0, 25) or IsControlJustReleased(0, 226)) then
                 resetPlayerCam(playerState.lastCam, false)
             end
         end

--- a/client/utils.lua
+++ b/client/utils.lua
@@ -123,5 +123,8 @@ function getCamByVehicleType()
 end
 
 function isPlayerAiming()
+    if not IsUsingKeyboard(0) and cache.vehicle then
+        return (IsPlayerFreeAiming(cache.playerId) or IsControlPressed(0, 226)) and true or false
+    end
     return (IsPlayerFreeAiming(cache.playerId) or IsControlPressed(0, 25)) and true or false
 end


### PR DESCRIPTION
As title says, this prevents a player from being forced into first person when braking in a vehicle using a controller.

Currently, the script uses control index 25 which is the right mouse button but also the left trigger on controllers which results in players being forced into first person when braking or reversing in a vehicle using a controller. I changed this to use control index 226 (Left bumper) when a player is on controller and in a vehicle. The left bumper is also the correct key for aiming in a vehicle on a controller so players are still forced into first person if they aim in a vehicle on controller.