### PR TITLE
fix(xt-fpp): prevent FPP forcing during finger pointing and bike kicks

### DIFF
--- a/client/cl_vehicles.lua
+++ b/client/cl_vehicles.lua
@@ -26,7 +26,7 @@ local function vehicleLoop()
                 end
             end
 
-            if isAiming or forceDriver or forcePassenger then
+            if (isAiming and FPPVehicleWeapon) or forceDriver or forcePassenger then
                 UTILS.setCamByVehicleType(4)
             end
 

--- a/modules/utils.lua
+++ b/modules/utils.lua
@@ -98,7 +98,9 @@ function utils.getCamByVehicleType()
 end
 
 function utils.isPlayerAiming()
-    return (IsPlayerFreeAiming(cache.playerId) or IsControlPressed(0, 25)) and true or false
+    if not cache.weapon then return false end
+
+    return IsPlayerFreeAiming(cache.playerId) or IsControlPressed(0, 25)
 end
 
 function utils.getPlayerCam()


### PR DESCRIPTION
Added a weapon check to prevent forced first-person while finger pointing or doing melee attacks on a bike without a weapon equipped.